### PR TITLE
Add additional Jest tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = {presets: ['@babel/preset-env']};

--- a/tests/Board.test.js
+++ b/tests/Board.test.js
@@ -1,0 +1,18 @@
+const Board = require('../server/game/Board');
+
+describe('Board initialization', () => {
+  test('board has expected squares and getSquareAt works', () => {
+    const board = new Board();
+    expect(board.squares.length).toBe(13);
+    const go = board.getSquareAt(0);
+    expect(go.type).toBe('go');
+    expect(go.name).toBe('Départ');
+    const belleville = board.getSquareAt(1);
+    expect(belleville.name).toBe('Boulevard de Belleville');
+    expect(belleville.group).toBe('brown');
+    const chance = board.getSquareAt(7);
+    expect(chance.type).toBe('card');
+    const jail = board.getSquareAt(9);
+    expect(jail.type).toBe('jail');
+  });
+});

--- a/tests/Property.test.js
+++ b/tests/Property.test.js
@@ -1,0 +1,28 @@
+const Game = require('../server/game/Game');
+
+describe('Property buying and building', () => {
+  let game;
+  let player;
+  let property;
+
+  beforeEach(() => {
+    game = new Game();
+    player = game.addPlayer('Alice', 's1');
+    property = game.board.getSquareAt(1); // Boulevard de Belleville
+    player.buyProperty(property, property.price);
+  });
+
+  test('buyHouse and buyHotel', () => {
+    expect(property.owner).toBe(player);
+    const house = game.buyHouse(player.id, property.id);
+    expect(house.success).toBe(true);
+    expect(property.houses).toBe(1);
+
+    // give player enough houses to buy hotel
+    property.houses = 4;
+    const hotel = game.buyHotel(player.id, property.id);
+    expect(hotel.success).toBe(true);
+    expect(property.hotel).toBe(true);
+    expect(property.houses).toBe(0);
+  });
+});

--- a/tests/RevengeAlliance.test.js
+++ b/tests/RevengeAlliance.test.js
@@ -1,0 +1,39 @@
+const Game = require('../server/game/Game');
+const Player = require('../server/game/Player');
+
+describe('Revenge loan and alliances', () => {
+  test('activate and repay revenge loan', () => {
+    const player = new Player('Alice', 's1');
+    const result = player.activateRevenge();
+    expect(result.success).toBe(true);
+    expect(player.revengeActive).toBe(true);
+    expect(player.money).toBe(2000); // 1500 + 500
+
+    player.money = 1000; // ensure enough to repay
+    let last;
+    for (let i = 0; i < 5; i++) {
+      last = player.updateRevengeLoan();
+    }
+    expect(last.success).toBe(true);
+    expect(player.revengeActive).toBe(false);
+    expect(player.money).toBe(250); // 1000 - 750
+  });
+
+  test('create and break alliance', () => {
+    const game = new Game();
+    const p1 = game.addPlayer('Alice', 's1');
+    const p2 = game.addPlayer('Bob', 's2');
+
+    const create = game.createAlliance(p1.id, p2.id);
+    expect(create.success).toBe(true);
+    expect(p1.currentAlliance.player).toBe(p2);
+    expect(p2.currentAlliance.player).toBe(p1);
+
+    const broken = game.breakAlliance(p1.id, true);
+    expect(broken.success).toBe(true);
+    expect(p1.currentAlliance).toBeNull();
+    expect(p2.currentAlliance).toBeNull();
+    expect(p1.money).toBe(1300); // 1500 - 200 penalty
+    expect(p2.money).toBe(1700); // 1500 + 200 received
+  });
+});

--- a/tests/SocketHandlers.test.js
+++ b/tests/SocketHandlers.test.js
@@ -1,0 +1,54 @@
+const { createLobby, joinLobby, leaveLobby, lobbies } = require('../server/socket/lobby');
+const gameEvents = require('../server/socket/gameEvents');
+
+describe('Socket handlers', () => {
+  let io;
+  let emitMock;
+
+  const makeSocket = id => ({
+    id,
+    join: jest.fn(),
+    to: jest.fn(() => ({ emit: jest.fn() })),
+    leave: jest.fn()
+  });
+
+  beforeEach(() => {
+    for (const id of Object.keys(lobbies)) delete lobbies[id];
+    emitMock = jest.fn();
+    io = { of: jest.fn(() => ({ to: jest.fn(() => ({ emit: emitMock })) })) };
+  });
+
+  test('startGame only allowed for host', () => {
+    const hostSocket = makeSocket('s1');
+    const resCreate = createLobby(hostSocket, { playerName: 'Host', lobbyName: 'L1' });
+    const lobbyId = resCreate.lobby.id;
+    const playerSocket = makeSocket('s2');
+    joinLobby(playerSocket, { playerName: 'Bob', lobbyId });
+
+    let result = gameEvents.startGame(io, playerSocket, {});
+    expect(result.success).toBe(false);
+
+    result = gameEvents.startGame(io, hostSocket, {});
+    expect(result.success).toBe(true);
+    expect(io.of).toHaveBeenCalledWith('/game');
+
+    leaveLobby(hostSocket, { lobbyId });
+    leaveLobby(playerSocket, { lobbyId });
+  });
+
+  test('createAlliance event', () => {
+    const hostSocket = makeSocket('s3');
+    const { lobby } = createLobby(hostSocket, { playerName: 'Alice', lobbyName: 'L2' });
+    const socket2 = makeSocket('s4');
+    joinLobby(socket2, { playerName: 'Bob', lobbyId: lobby.id });
+    gameEvents.startGame(io, hostSocket, {});
+
+    const lobbyObj = lobbies[lobby.id];
+    const bobId = Object.values(lobbyObj.game.players).find(p => p.socketId === socket2.id).id;
+    const allianceRes = gameEvents.createAlliance(io, hostSocket, { targetPlayerId: bobId });
+    expect(allianceRes.success).toBe(true);
+
+    leaveLobby(hostSocket, { lobbyId: lobby.id });
+    leaveLobby(socket2, { lobbyId: lobby.id });
+  });
+});


### PR DESCRIPTION
## Summary
- add babel config for Jest
- cover board setup, building, revenge loan, alliances
- exercise socket event handlers

## Testing
- `npm test`