### PR TITLE
Add property actions to client and server

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,4 +1,23 @@
-import { initSocket, getSocket, createLobby, joinLobby, listLobbies, startGame, rollDice, placeBid, passBid, activateRevenge, declineRevenge, createAlliance, breakAlliance, applyCardEffect } from './socket';
+import {
+  initSocket,
+  getSocket,
+  createLobby,
+  joinLobby,
+  listLobbies,
+  startGame,
+  rollDice,
+  placeBid,
+  passBid,
+  activateRevenge,
+  declineRevenge,
+  createAlliance,
+  breakAlliance,
+  applyCardEffect,
+  buyHouse,
+  buyHotel,
+  mortgageProperty,
+  unmortgageProperty
+} from './socket';
 import { getGameState, subscribeToGameState } from './state/game';
 import { getUIState, subscribeToUIState } from './state/ui';
 
@@ -586,7 +605,26 @@ function renderPlayersInfo(players) {
     const playerElement = document.createElement('div');
     playerElement.className = `player-card ${player.bankrupt ? 'bankrupt' : ''}`;
     playerElement.dataset.id = player.id;
-    
+
+    const socket = getSocket();
+    const isSelf = socket && socket.id === player.socketId;
+
+    let propertiesHtml = '';
+    if (isSelf && player.properties.length > 0) {
+      propertiesHtml = '<ul class="property-actions">';
+      player.properties.forEach(prop => {
+        propertiesHtml += `
+          <li>
+            <span class="prop-name">${prop.name}</span>
+            <button class="buy-house-btn" data-id="${prop.id}">+Maison</button>
+            <button class="buy-hotel-btn" data-id="${prop.id}">+Hôtel</button>
+            <button class="mortgage-btn" data-id="${prop.id}">Hyp.</button>
+            <button class="unmortgage-btn" data-id="${prop.id}">Lever</button>
+          </li>`;
+      });
+      propertiesHtml += '</ul>';
+    }
+
     playerElement.innerHTML = `
       <div class="player-header">
         <div class="player-name">${player.name}</div>
@@ -601,9 +639,27 @@ function renderPlayersInfo(players) {
         ${player.revengeActive ? '<div class="revenge-active"><i class="fas fa-exclamation-triangle"></i> Prêt actif</div>' : ''}
         ${player.currentAlliance ? '<div class="alliance"><i class="fas fa-handshake"></i> En alliance</div>' : ''}
       </div>
+      ${propertiesHtml}
     `;
-    
+
     playersInfo.appendChild(playerElement);
+  });
+
+  // Ajouter les gestionnaires sur les boutons des propriétés
+  document.querySelectorAll('.buy-house-btn').forEach(btn => {
+    btn.addEventListener('click', () => buyHouse(parseInt(btn.dataset.id)));
+  });
+
+  document.querySelectorAll('.buy-hotel-btn').forEach(btn => {
+    btn.addEventListener('click', () => buyHotel(parseInt(btn.dataset.id)));
+  });
+
+  document.querySelectorAll('.mortgage-btn').forEach(btn => {
+    btn.addEventListener('click', () => mortgageProperty(parseInt(btn.dataset.id)));
+  });
+
+  document.querySelectorAll('.unmortgage-btn').forEach(btn => {
+    btn.addEventListener('click', () => unmortgageProperty(parseInt(btn.dataset.id)));
   });
 }
 

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -106,6 +106,26 @@ export function initSocket(url = window.location.origin) {
     setCardState({ applied: true, playerId, cardId, success, message });
     updateGameState(gameState);
   });
+
+  socket.on('house_bought', ({ playerId, propertyId, success, message, gameState }) => {
+    console.log('Maison achetée:', playerId, propertyId, success, message);
+    updateGameState(gameState);
+  });
+
+  socket.on('hotel_bought', ({ playerId, propertyId, success, message, gameState }) => {
+    console.log("Hôtel acheté:", playerId, propertyId, success, message);
+    updateGameState(gameState);
+  });
+
+  socket.on('property_mortgaged', ({ playerId, propertyId, success, message, gameState }) => {
+    console.log('Propriété hypothéquée:', playerId, propertyId, success, message);
+    updateGameState(gameState);
+  });
+
+  socket.on('property_unmortgaged', ({ playerId, propertyId, success, message, gameState }) => {
+    console.log("Hypothèque levée:", playerId, propertyId, success, message);
+    updateGameState(gameState);
+  });
   
   socket.on('disconnect', () => {
     console.log('Déconnecté du serveur');
@@ -366,6 +386,74 @@ export function applyCardEffect(cardId, params) {
     }
     
     socket.emit('apply_card_effect', { cardId, params }, (response) => {
+      if (response && response.success) {
+        resolve(response);
+      } else {
+        reject(new Error(response ? response.message : 'Erreur inconnue'));
+      }
+    });
+  });
+}
+
+export function buyHouse(propertyId) {
+  return new Promise((resolve, reject) => {
+    if (!socket) {
+      reject(new Error('Socket non initialisé'));
+      return;
+    }
+
+    socket.emit('buy_house', { propertyId }, (response) => {
+      if (response && response.success) {
+        resolve(response);
+      } else {
+        reject(new Error(response ? response.message : 'Erreur inconnue'));
+      }
+    });
+  });
+}
+
+export function buyHotel(propertyId) {
+  return new Promise((resolve, reject) => {
+    if (!socket) {
+      reject(new Error('Socket non initialisé'));
+      return;
+    }
+
+    socket.emit('buy_hotel', { propertyId }, (response) => {
+      if (response && response.success) {
+        resolve(response);
+      } else {
+        reject(new Error(response ? response.message : 'Erreur inconnue'));
+      }
+    });
+  });
+}
+
+export function mortgageProperty(propertyId) {
+  return new Promise((resolve, reject) => {
+    if (!socket) {
+      reject(new Error('Socket non initialisé'));
+      return;
+    }
+
+    socket.emit('mortgage_property', { propertyId }, (response) => {
+      if (response && response.success) {
+        resolve(response);
+      } else {
+        reject(new Error(response ? response.message : 'Erreur inconnue'));
+      }
+    });
+  });
+}
+
+export function unmortgageProperty(propertyId) {
+  return new Promise((resolve, reject) => {
+    if (!socket) {
+      reject(new Error('Socket non initialisé'));
+      return;
+    }
+
+    socket.emit('unmortgage_property', { propertyId }, (response) => {
       if (response && response.success) {
         resolve(response);
       } else {

--- a/server/socket/gameEvents.js
+++ b/server/socket/gameEvents.js
@@ -417,6 +417,142 @@ function applyCardEffect(io, socket, { cardId, params }) {
   return result;
 }
 
+function buyHouse(io, socket, { propertyId }) {
+  if (typeof propertyId !== 'number') {
+    return { success: false, message: 'Propriété invalide' };
+  }
+
+  const lobby = getLobbyBySocketId(socket.id);
+
+  if (!lobby || !lobby.game) {
+    return { success: false, message: 'Partie non trouvée' };
+  }
+
+  const game = lobby.game;
+
+  const playerId = Object.keys(game.players).find(
+    id => game.players[id].socketId === socket.id
+  );
+
+  if (!playerId) {
+    return { success: false, message: 'Joueur non trouvé' };
+  }
+
+  const result = game.buyHouse(playerId, propertyId);
+
+  io.of('/game').to(lobby.id).emit('house_bought', {
+    playerId,
+    propertyId,
+    success: result.success,
+    message: result.message,
+    gameState: game.getGameState()
+  });
+
+  return result;
+}
+
+function buyHotel(io, socket, { propertyId }) {
+  if (typeof propertyId !== 'number') {
+    return { success: false, message: 'Propriété invalide' };
+  }
+
+  const lobby = getLobbyBySocketId(socket.id);
+
+  if (!lobby || !lobby.game) {
+    return { success: false, message: 'Partie non trouvée' };
+  }
+
+  const game = lobby.game;
+
+  const playerId = Object.keys(game.players).find(
+    id => game.players[id].socketId === socket.id
+  );
+
+  if (!playerId) {
+    return { success: false, message: 'Joueur non trouvé' };
+  }
+
+  const result = game.buyHotel(playerId, propertyId);
+
+  io.of('/game').to(lobby.id).emit('hotel_bought', {
+    playerId,
+    propertyId,
+    success: result.success,
+    message: result.message,
+    gameState: game.getGameState()
+  });
+
+  return result;
+}
+
+function mortgageProperty(io, socket, { propertyId }) {
+  if (typeof propertyId !== 'number') {
+    return { success: false, message: 'Propriété invalide' };
+  }
+
+  const lobby = getLobbyBySocketId(socket.id);
+
+  if (!lobby || !lobby.game) {
+    return { success: false, message: 'Partie non trouvée' };
+  }
+
+  const game = lobby.game;
+
+  const playerId = Object.keys(game.players).find(
+    id => game.players[id].socketId === socket.id
+  );
+
+  if (!playerId) {
+    return { success: false, message: 'Joueur non trouvé' };
+  }
+
+  const result = game.mortgageProperty(playerId, propertyId);
+
+  io.of('/game').to(lobby.id).emit('property_mortgaged', {
+    playerId,
+    propertyId,
+    success: result.success,
+    message: result.message,
+    gameState: game.getGameState()
+  });
+
+  return result;
+}
+
+function unmortgageProperty(io, socket, { propertyId }) {
+  if (typeof propertyId !== 'number') {
+    return { success: false, message: 'Propriété invalide' };
+  }
+
+  const lobby = getLobbyBySocketId(socket.id);
+
+  if (!lobby || !lobby.game) {
+    return { success: false, message: 'Partie non trouvée' };
+  }
+
+  const game = lobby.game;
+
+  const playerId = Object.keys(game.players).find(
+    id => game.players[id].socketId === socket.id
+  );
+
+  if (!playerId) {
+    return { success: false, message: 'Joueur non trouvé' };
+  }
+
+  const result = game.unmortgageProperty(playerId, propertyId);
+
+  io.of('/game').to(lobby.id).emit('property_unmortgaged', {
+    playerId,
+    propertyId,
+    success: result.success,
+    message: result.message,
+    gameState: game.getGameState()
+  });
+
+  return result;
+}
+
 module.exports = {
   startGame,
   rollDice,
@@ -426,5 +562,9 @@ module.exports = {
   declineRevenge,
   createAlliance,
   breakAlliance,
-  applyCardEffect
+  applyCardEffect,
+  buyHouse,
+  buyHotel,
+  mortgageProperty,
+  unmortgageProperty
 };

--- a/server/socket/handlers.js
+++ b/server/socket/handlers.js
@@ -8,7 +8,11 @@ const {
   declineRevenge,
   createAlliance,
   breakAlliance,
-  applyCardEffect
+  applyCardEffect,
+  buyHouse,
+  buyHotel,
+  mortgageProperty,
+  unmortgageProperty
 } = require('./gameEvents');
 
 function initSocketHandlers(io) {
@@ -107,6 +111,26 @@ function initSocketHandlers(io) {
     
     socket.on('apply_card_effect', (data, callback) => {
       const result = applyCardEffect(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('buy_house', (data, callback) => {
+      const result = buyHouse(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('buy_hotel', (data, callback) => {
+      const result = buyHotel(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('mortgage_property', (data, callback) => {
+      const result = mortgageProperty(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('unmortgage_property', (data, callback) => {
+      const result = unmortgageProperty(io, socket, data);
       if (callback) callback(result);
     });
     


### PR DESCRIPTION
## Summary
- add socket events for property upgrades and mortgage actions
- expose events in server handlers
- update client socket helpers
- show property action buttons for current player

## Testing
- `npm test` *(fails: jest not found)*