### PR TITLE
Fix Babel config parse error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,3 @@
-{"presets": ["@babel/preset-env"]}
+{
+  "presets": ["@babel/preset-env"]
+}


### PR DESCRIPTION
## Summary
- restore JSON format for `.babelrc`

## Testing
- `npm test`
