### PR TITLE
Add interactive UI for KCRAP cards

### DIFF
--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -56,6 +56,11 @@ export function initSocket(url = window.location.origin) {
   socket.on('dice_rolled', ({ result, gameState }) => {
     console.log('Dés lancés:', result);
     setDiceResult(result);
+    if (result.action && result.action.type === 'card') {
+      setCardState({ card: result.action.card, applied: false });
+    } else {
+      setCardState(null);
+    }
     updateGameState(gameState);
   });
   


### PR DESCRIPTION
## Summary
- handle card draws in the socket client and store in UI state
- implement interactive forms for KCRAP cards (exchange, restructure, hostile) in `handleCardUI`
- apply card state reset on dice rolls when no card is drawn

## Testing
- `npm test`