### PR TITLE
Add client reconnect support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ npm test
 
 Le serveur prend en charge la reconnexion des joueurs via l'événement `reconnect_player`.
 Les chemins de sauvegarde et le port du serveur peuvent être configurés dans `server/config.js`.
+
+Le client tente désormais automatiquement de se reconnecter lorsqu'un état joueur est
+présent dans `localStorage`. Si la reconnexion réussit et qu'une partie est en cours,
+l'écran de jeu est restauré.

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -11,7 +11,7 @@ import {
 // Gestionnaire de connexion au serveur
 let socket = null;
 
-export function initSocket(url = window.location.origin) {
+export function initSocket(url = window.location.origin, onConnect) {
   if (socket) {
     socket.disconnect();
   }
@@ -25,6 +25,7 @@ export function initSocket(url = window.location.origin) {
   // Écouter l'événement de connexion
   socket.on('connect', () => {
     console.log('Connexion socket.io établie avec succès, socket ID:', socket.id);
+    if (onConnect) onConnect();
   });
   
   socket.on('connect_error', (error) => {
@@ -461,6 +462,23 @@ export function unmortgageProperty(propertyId) {
     socket.emit('unmortgage_property', { propertyId }, (response) => {
       if (response && response.success) {
         resolve(response);
+      } else {
+        reject(new Error(response ? response.message : 'Erreur inconnue'));
+      }
+    });
+  });
+}
+
+export function reconnectPlayer(lobbyId, token, previousSocketId) {
+  return new Promise((resolve, reject) => {
+    if (!socket) {
+      reject(new Error('Socket non initialisé'));
+      return;
+    }
+
+    socket.emit('reconnect_player', { lobbyId, token, previousSocketId }, (response) => {
+      if (response && response.success) {
+        resolve(response.lobby);
       } else {
         reject(new Error(response ? response.message : 'Erreur inconnue'));
       }

--- a/server/socket/lobby.js
+++ b/server/socket/lobby.js
@@ -173,7 +173,8 @@ function reconnectPlayer(socket, { lobbyId, token, previousSocketId }) {
       name: lobby.name,
       players: lobby.players,
       isHost: socket.id === lobby.host,
-      token: player.token
+      token: player.token,
+      gameState: lobby.game ? lobby.game.getGameState() : null
     }
   };
 }


### PR DESCRIPTION
## Summary
- return game state from reconnect endpoint on the server
- expose `reconnectPlayer` helper on the client
- persist lobby connection details in localStorage and restore them when possible
- document automatic reconnection in README

## Testing
- `npm test`