### PR TITLE
Fix temporary card effect updates

### DIFF
--- a/server/game/Game.js
+++ b/server/game/Game.js
@@ -625,6 +625,24 @@ class Game {
     return true;
   }
 
+  updateTemporaryEffects() {
+    this.board.squares.forEach(square => {
+      if (square.type === 'property') {
+        if (typeof square.cryptoTurnsLeft === 'number') {
+          square.cryptoTurnsLeft--;
+          if (square.cryptoTurnsLeft <= 0) {
+            delete square.cryptoTurnsLeft;
+            delete square.cryptoFluctuation;
+          }
+        }
+
+        if (square.updateTemporaryOwnership()) {
+          this.log.push(`${square.name} retourne à ${square.owner.name}`);
+        }
+      }
+    });
+  }
+
   applyCardEffect(playerId, cardId, params) {
     if (this.state !== 'card') {
       return { 
@@ -732,11 +750,14 @@ class Game {
     // Mise à jour de la perturbation numérique
     if (this.digitalDisruptionTurnsLeft > 0) {
       this.digitalDisruptionTurnsLeft--;
-      
+
       if (this.digitalDisruptionTurnsLeft === 0) {
         this.log.push("La perturbation numérique s'est terminée");
       }
     }
+
+    // Mise à jour des effets temporaires des propriétés
+    this.updateTemporaryEffects();
     
     // Passer au joueur suivant
     do {

--- a/server/game/Property.js
+++ b/server/game/Property.js
@@ -89,6 +89,13 @@ class Property {
     if (this.owner && !this.houses && !this.hotel) {
       this.originalOwner = this.owner;
       this.temporaryOwner = newOwner;
+      // Changer temporairement le propriétaire
+      this.owner = newOwner;
+      const idx = this.originalOwner.properties.findIndex(p => p.id === this.id);
+      if (idx > -1) {
+        this.originalOwner.properties.splice(idx, 1);
+      }
+      newOwner.properties.push(this);
       this.temporaryOwnerTurns = turns;
       return true;
     }
@@ -98,9 +105,20 @@ class Property {
   updateTemporaryOwnership() {
     if (this.temporaryOwner) {
       this.temporaryOwnerTurns--;
-      
+
       if (this.temporaryOwnerTurns <= 0) {
+        // Retirer la propriété du joueur temporaire
+        const idxTemp = this.temporaryOwner.properties.findIndex(p => p.id === this.id);
+        if (idxTemp > -1) {
+          this.temporaryOwner.properties.splice(idxTemp, 1);
+        }
+
+        // Restituer la propriété à son propriétaire d'origine
         this.owner = this.originalOwner;
+        if (!this.originalOwner.properties.includes(this)) {
+          this.originalOwner.properties.push(this);
+        }
+
         this.temporaryOwner = null;
         this.originalOwner = null;
         return true; // Propriété rendue

--- a/server/game/cards/KcrapCard.js
+++ b/server/game/cards/KcrapCard.js
@@ -212,7 +212,13 @@ class KcrapCard {
     }
     
     // Prendre le contrôle de la propriété
-    targetProperty.applyHostileTakeover(player, 3); // 3 tours
+    if (targetProperty.applyHostileTakeover(player, 3)) {
+      const index = originalOwner.properties.findIndex(p => p.id === targetProperty.id);
+      if (index > -1) {
+        originalOwner.properties.splice(index, 1);
+      }
+      player.properties.push(targetProperty);
+    }
     
     this.effectApplied = true;
     


### PR DESCRIPTION
## Summary
- transfer property ownership during hostile takeover
- restore ownership and crypto effects each turn
- track expiry of crypto and hostile effects

## Testing
- `npm test`