### PR TITLE
Improve digital disruption persistence

### DIFF
--- a/server/game/Game.js
+++ b/server/game/Game.js
@@ -67,7 +67,8 @@ class Game {
     game.currentPlayer = game.players[state.currentPlayer] || null;
     game.state = state.state;
     game.turnCount = state.turnCount;
-    game.digitalDisruptionTurnsLeft = state.digitalDisruption ? 1 : 0;
+    game.digitalDisruptionTurnsLeft = state.digitalDisruptionTurnsLeft ||
+      (state.digitalDisruption ? 1 : 0);
     game.lastDiceTotal = state.lastDiceTotal || 0;
     game.log = state.log || [];
 
@@ -889,6 +890,7 @@ class Game {
       turnCount: this.turnCount,
       board: this.board.getState(),
       digitalDisruption: this.digitalDisruptionTurnsLeft > 0,
+      digitalDisruptionTurnsLeft: this.digitalDisruptionTurnsLeft,
       log: this.log.slice(-20) // Derniers 20 événements du log
     };
   }

--- a/tests/Game.test.js
+++ b/tests/Game.test.js
@@ -228,10 +228,13 @@ describe('Game core methods', () => {
     const fs = require('fs');
     const path = require('path');
 
+    game.applyDigitalDisruption(2);
+
     saveGame(game);
     const loaded = loadGame(game.id);
     expect(loaded).not.toBeNull();
     expect(Object.keys(loaded.players)).toHaveLength(2);
+    expect(loaded.digitalDisruptionTurnsLeft).toBe(2);
 
     fs.unlinkSync(path.join(SAVE_PATH, `${game.id}.json`));
   });


### PR DESCRIPTION
## Summary
- preserve remaining turns for digital disruption in saved game state
- add test for restoring digital disruption turns when loading a game

## Testing
- `npm test`