### PR TITLE
Enable persistent lobby games

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ const path = require('path');
 const { PORT } = require('./config');
 const { initSocketHandlers } = require('./socket/handlers');
 const { loadSavedGames } = require('./utils/gamePersistence');
+const { registerLoadedGames } = require('./socket/lobby');
 
 // Configuration du serveur
 
@@ -21,6 +22,7 @@ async function startServer() {
     // Charger les parties sauvegardées
     const saved = loadSavedGames();
     console.log(`Jeux sauvegardés chargés: ${Object.keys(saved).length}`);
+    registerLoadedGames(saved);
 
     // Configuration de Socket.io
     const io = socketIO(server, {

--- a/server/socket/gameEvents.js
+++ b/server/socket/gameEvents.js
@@ -49,7 +49,7 @@ function startGame(io, socket, data) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return { success: true };
 }
@@ -83,7 +83,7 @@ function rollDice(io, socket, data) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }
@@ -135,7 +135,7 @@ function placeBid(io, socket, { amount }) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }
@@ -195,7 +195,7 @@ function passBid(io, socket) {
     });
   }
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return { success: true };
 }
@@ -243,7 +243,7 @@ function activateRevenge(io, socket) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }
@@ -291,7 +291,7 @@ function declineRevenge(io, socket) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }
@@ -335,7 +335,7 @@ function createAlliance(io, socket, { targetPlayerId }) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }
@@ -379,7 +379,7 @@ function breakAlliance(io, socket, { unilateral = true }) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }
@@ -431,7 +431,7 @@ function applyCardEffect(io, socket, { cardId, params }) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }
@@ -467,7 +467,7 @@ function buyHouse(io, socket, { propertyId }) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }
@@ -503,7 +503,7 @@ function buyHotel(io, socket, { propertyId }) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }
@@ -539,7 +539,7 @@ function mortgageProperty(io, socket, { propertyId }) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }
@@ -575,7 +575,7 @@ function unmortgageProperty(io, socket, { propertyId }) {
     gameState: game.getGameState()
   });
 
-  saveGame(game);
+  saveGame(game, lobby);
 
   return result;
 }

--- a/server/socket/lobby.js
+++ b/server/socket/lobby.js
@@ -293,8 +293,27 @@ function generateLobbyId() {
   do {
     id = Math.random().toString(36).substring(2, 8).toUpperCase();
   } while (lobbies[id]);
-  
+
   return id;
+}
+
+function registerLoadedGames(savedGames) {
+  for (const gameId of Object.keys(savedGames)) {
+    const { game, lobby: lobbyData } = savedGames[gameId];
+    if (!game || !lobbyData) continue;
+
+    lobbies[lobbyData.id] = {
+      id: lobbyData.id,
+      name: lobbyData.name || `Restored ${lobbyData.id}`,
+      host: lobbyData.host,
+      players: lobbyData.players.map(p => ({
+        ...p,
+        connected: false
+      })),
+      game,
+      createdAt: lobbyData.createdAt || Date.now()
+    };
+  }
 }
 
 module.exports = {
@@ -306,5 +325,6 @@ module.exports = {
   getLobbyBySocketId,
   getLobbyById,
   handleDisconnect,
-  lobbies
+  lobbies,
+  registerLoadedGames
 };

--- a/server/utils/gamePersistence.js
+++ b/server/utils/gamePersistence.js
@@ -9,11 +9,24 @@ function ensureSaveDir() {
   }
 }
 
-function saveGame(game) {
+function saveGame(game, lobby = null) {
   try {
     ensureSaveDir();
     const file = path.join(SAVE_PATH, `${game.id}.json`);
-    fs.writeFileSync(file, JSON.stringify(game.getGameState(), null, 2));
+
+    const data = { game: game.getGameState() };
+
+    if (lobby) {
+      data.lobby = {
+        id: lobby.id,
+        name: lobby.name,
+        host: lobby.host,
+        createdAt: lobby.createdAt,
+        players: lobby.players
+      };
+    }
+
+    fs.writeFileSync(file, JSON.stringify(data, null, 2));
   } catch (err) {
     console.error('Erreur lors de la sauvegarde du jeu:', err);
   }
@@ -25,7 +38,12 @@ function loadGame(gameId) {
     const file = path.join(SAVE_PATH, `${gameId}.json`);
     if (!fs.existsSync(file)) return null;
     const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-    return Game.fromState(data);
+
+    const gameState = data.game || data;
+    const game = Game.fromState(gameState);
+    const lobby = data.lobby || null;
+
+    return { game, lobby };
   } catch (err) {
     console.error('Erreur lors du chargement du jeu:', err);
     return null;

--- a/tests/Game.test.js
+++ b/tests/Game.test.js
@@ -233,8 +233,8 @@ describe('Game core methods', () => {
     saveGame(game);
     const loaded = loadGame(game.id);
     expect(loaded).not.toBeNull();
-    expect(Object.keys(loaded.players)).toHaveLength(2);
-    expect(loaded.digitalDisruptionTurnsLeft).toBe(2);
+    expect(Object.keys(loaded.game.players)).toHaveLength(2);
+    expect(loaded.game.digitalDisruptionTurnsLeft).toBe(2);
 
     fs.unlinkSync(path.join(SAVE_PATH, `${game.id}.json`));
   });


### PR DESCRIPTION
## Summary
- extend game persistence with lobby metadata
- register saved games at startup
- restore lobbies from saved files
- update tests for new persistence format

## Testing
- `npm test`