### PR TITLE
Restore socket IDs when reloading games

### DIFF
--- a/server/game/Game.js
+++ b/server/game/Game.js
@@ -32,7 +32,7 @@ class Game {
     // Reconstruire les joueurs
     game.players = {};
     state.players.forEach(pData => {
-      const player = new Player(pData.name, null);
+      const player = new Player(pData.name, pData.socketId || null);
       player.id = pData.id;
       player.money = pData.money;
       player.position = pData.position;

--- a/tests/Game.test.js
+++ b/tests/Game.test.js
@@ -236,6 +236,25 @@ describe('Game core methods', () => {
     expect(Object.keys(loaded.game.players)).toHaveLength(2);
     expect(loaded.game.digitalDisruptionTurnsLeft).toBe(2);
 
-    fs.unlinkSync(path.join(SAVE_PATH, `${game.id}.json`));
+  fs.unlinkSync(path.join(SAVE_PATH, `${game.id}.json`));
+  });
+
+  test('fromState restores socket IDs', () => {
+    const alice = game.addPlayer('Alice', 's1');
+    const bob = game.addPlayer('Bob', 's2');
+
+    const state = game.getGameState();
+    state.players.forEach(p => {
+      if (p.name === 'Alice') p.socketId = 's1';
+      if (p.name === 'Bob') p.socketId = 's2';
+    });
+
+    const restored = Game.fromState(state);
+    const restoredPlayers = Object.values(restored.players);
+    const restoredAlice = restoredPlayers.find(p => p.name === 'Alice');
+    const restoredBob = restoredPlayers.find(p => p.name === 'Bob');
+
+    expect(restoredAlice.socketId).toBe('s1');
+    expect(restoredBob.socketId).toBe('s2');
   });
 });


### PR DESCRIPTION
## Summary
- keep each player's socketId when reconstructing a game from saved state
- test that Game.fromState restores socket IDs

## Testing
- `npm test`