### PR TITLE
Add sharable lobby URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ Lorsque la page d'accueil est affichée, ce pseudonyme est automatiquement
 prérempli dans les champs "Votre nom". Ainsi, il n'est plus nécessaire de le
 renseigner à chaque nouvelle connexion.
 
+### Liens directs vers les salons
+
+Il est possible d'accéder directement à un salon via l'URL `http://<hôte>:<port>/ID_SALON`.
+Au chargement, le client détecte cet identifiant et tente de rejoindre
+automatiquement le salon avec le pseudonyme enregistré ou préremplit le champ
+"Code du salon".
+Dans l'écran du lobby, le code d'invitation apparaît comme un lien menant à
+`/ID_SALON` afin de pouvoir le partager facilement.
+
 ### Résumé du mode KCRAP
 
 Lorsque qu'un joueur s'arrête sur la case « KCRAP », il pioche une carte spéciale pouvant déclencher l'un des effets suivants :

--- a/server/index.js
+++ b/server/index.js
@@ -43,6 +43,11 @@ async function startServer() {
     app.get('/', (req, res) => {
       res.sendFile(path.join(__dirname, '../client/public/index.html'));
     });
+
+    // Servir index.html pour tout identifiant de lobby
+    app.get('/:lobbyId', (req, res) => {
+      res.sendFile(path.join(__dirname, '../client/public/index.html'));
+    });
     
     // Initialiser les gestionnaires de socket
     initSocketHandlers(io);


### PR DESCRIPTION
## Summary
- serve `index.html` for `/LOBBY_ID` URLs
- auto-join lobby based on browser pathname
- push lobby ID to history and show link in lobby screen
- document new behaviour

## Testing
- `npm test`