### PR TITLE
Enhance card deck logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Lorsque qu'un joueur s'arrête sur la case « KCRAP », il pioche une carte sp
 - **Perturbation numérique** : taxation de 10 % des loyers pendant deux tours.
 - **Aller en prison** : le joueur est immédiatement envoyé en prison.
 
+Le paquet s'adapte également au contexte : les cartes visant à prendre ou à
+échanger une propriété ne sont plus tirées tant qu'aucun joueur n'en possède.
+
 Ces cartes ajoutent une dimension stratégique supplémentaire. Consultez [docs/guide_utilisation.md](docs/guide_utilisation.md) pour la description complète de chaque règle.
 
 ## Guide d'utilisation avancée

--- a/server/game/Game.js
+++ b/server/game/Game.js
@@ -182,7 +182,7 @@ class Game {
       }
     } else if (currentSquare.type === 'card') {
       this.state = 'card';
-      const card = this.cardDeck.drawCard();
+      const card = this.cardDeck.drawCard(this);
       this.log.push(`${this.currentPlayer.name} a tiré une carte ${card.title}`);
       actionResult = { type: 'card', card };
     } else if (currentSquare.type === 'tax') {

--- a/server/game/cards/CardDeck.js
+++ b/server/game/cards/CardDeck.js
@@ -81,11 +81,38 @@ class CardDeck {
     this.currentIndex = 0;
   }
 
-  drawCard() {
+  isCardValid(card, game) {
+    if (!game) return true;
+
+    const anyPropertyOwned = Object.values(game.players).some(
+      p => p.properties && p.properties.length > 0
+    );
+
+    if (!anyPropertyOwned && (card.type === 'exchange' || card.type === 'hostile')) {
+      return false;
+    }
+
+    return true;
+  }
+
+  drawCard(game = null) {
     if (this.currentIndex >= this.cards.length) {
       this.shuffle();
     }
-    
+
+    if (game) {
+      let attempts = 0;
+      while (attempts < this.cards.length) {
+        const card = this.cards[this.currentIndex];
+        if (this.isCardValid(card, game)) {
+          this.currentIndex++;
+          return card;
+        }
+        this.currentIndex = (this.currentIndex + 1) % this.cards.length;
+        attempts++;
+      }
+    }
+
     return this.cards[this.currentIndex++];
   }
 }

--- a/tests/CardDeck.test.js
+++ b/tests/CardDeck.test.js
@@ -1,0 +1,16 @@
+const CardDeck = require('../server/game/cards/CardDeck');
+const KcrapCard = require('../server/game/cards/KcrapCard');
+const Game = require('../server/game/Game');
+
+test('skip property cards when none owned', () => {
+  const game = new Game();
+  const deck = new CardDeck();
+  deck.cards = [
+    new KcrapCard('ex','exchange','ex',''),
+    new KcrapCard('ho','hostile','ho',''),
+    new KcrapCard('di','digital','di',''),
+  ];
+  deck.currentIndex = 0;
+  const card = deck.drawCard(game);
+  expect(card.type).toBe('digital');
+});


### PR DESCRIPTION
## Summary
- improve README with note about contextual draw logic
- adapt card drawing to skip property cards when none are owned
- pass `Game` instance to `CardDeck.drawCard`
- test new card deck behavior

## Testing
- `npm test`