### PR TITLE
Fix auction passBid when auction finalizes

### DIFF
--- a/server/socket/gameEvents.js
+++ b/server/socket/gameEvents.js
@@ -234,9 +234,19 @@ function passBid(io, socket, data = {}) {
     };
   }
   
-  // Passer l'enchère
-  game.passBid(playerId);
-  
+  // Passer l'enchère et récupérer le résultat
+  const passResult = game.passBid(playerId);
+
+  // Si l'enchère a été finalisée pendant passBid
+  if (!game.currentAuction) {
+    io.of('/game').to(lobby.id).emit('auction_ended', {
+      result: passResult,
+      gameState: game.getGameState()
+    });
+    saveGame(game, lobby);
+    return passResult;
+  }
+
   // Avancer à la prochaine ronde d'enchères
   const roundResult = game.currentAuction.nextRound();
   

--- a/tests/PassBidEvent.test.js
+++ b/tests/PassBidEvent.test.js
@@ -1,0 +1,31 @@
+const { createLobby, joinLobby, lobbies } = require('../server/socket/lobby');
+const { startGame, passBid } = require('../server/socket/gameEvents');
+
+describe('passBid socket event', () => {
+  test('passing when auction ends should not throw', () => {
+    const io = { of: () => ({ to: () => ({ emit: jest.fn() }) }) };
+    const hostSocket = { id: 's1', join: jest.fn(), to: () => ({ emit: jest.fn() }) };
+    const playerSocket = { id: 's2', join: jest.fn(), to: () => ({ emit: jest.fn() }) };
+
+    const createRes = createLobby(hostSocket, { playerName: 'Alice', lobbyName: 'L1' });
+    const lobbyId = createRes.lobby.id;
+    const hostToken = createRes.lobby.token;
+
+    const joinRes = joinLobby(playerSocket, { playerName: 'Bob', lobbyId });
+    const playerToken = joinRes.lobby.token;
+
+    startGame(io, hostSocket, { token: hostToken });
+
+    const game = lobbies[lobbyId].game;
+    const property = game.board.getSquareAt(1);
+    game.startAuction(property);
+    game.state = 'auction';
+
+    expect(() => passBid(io, hostSocket, { token: hostToken })).not.toThrow();
+    expect(game.state).toBe('auction');
+
+    expect(() => passBid(io, playerSocket, { token: playerToken })).not.toThrow();
+    expect(game.state).toBe('rolling');
+    expect(game.currentAuction).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- handle auction finalization inside `passBid` socket event
- add regression test ensuring auction pass flow doesn't throw

## Testing
- `npm test`