### PR TITLE
Enable token color selection in lobby

### DIFF
--- a/client/public/css/style.css
+++ b/client/public/css/style.css
@@ -804,6 +804,14 @@ body::before {
   color: var(--primary-color);
 }
 
+.color-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+  display: inline-block;
+}
+
 /* Écran de jeu */
 #game-screen {
   display: grid;

--- a/client/src/components/Board.js
+++ b/client/src/components/Board.js
@@ -81,7 +81,7 @@ export function initBoard(target = 'board', infoTarget = null) {
           token.style.width = '20px';
           token.style.height = '20px';
           token.style.borderRadius = '50%';
-          token.style.background = '#FF00A8';
+          token.style.background = player.color || '#FF00A8';
           token.style.color = '#000';
           token.style.fontSize = '0.75rem';
           token.style.lineHeight = '20px';

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -167,7 +167,7 @@ export function getSocket() {
   return socket;
 }
 
-export function createLobby(playerName, lobbyName) {
+export function createLobby(playerName, lobbyName, color = '#FF00A8') {
   return new Promise((resolve, reject) => {
     if (!socket) {
       console.error('Socket non initialisé lors de createLobby');
@@ -175,7 +175,7 @@ export function createLobby(playerName, lobbyName) {
       return;
     }
     
-    console.log('Émission de l\'événement create_lobby avec:', { playerName, lobbyName });
+    console.log('Émission de l\'événement create_lobby avec:', { playerName, lobbyName, color });
     
     // Ajouter un timeout pour la réponse
     const timeout = setTimeout(() => {
@@ -183,7 +183,7 @@ export function createLobby(playerName, lobbyName) {
       reject(new Error('Délai de réponse dépassé'));
     }, 5000);
     
-    socket.emit('create_lobby', { playerName, lobbyName }, (response) => {
+    socket.emit('create_lobby', { playerName, lobbyName, color }, (response) => {
       clearTimeout(timeout);
       console.log('Réponse reçue pour create_lobby:', response);
       
@@ -196,7 +196,7 @@ export function createLobby(playerName, lobbyName) {
   });
 }
 
-export function joinLobby(playerName, lobbyId) {
+export function joinLobby(playerName, lobbyId, color = '#FF00A8') {
   return new Promise((resolve, reject) => {
     if (!socket) {
       console.error('Socket non initialisé lors de joinLobby');
@@ -204,7 +204,7 @@ export function joinLobby(playerName, lobbyId) {
       return;
     }
     
-    console.log('Émission de l\'événement join_lobby avec:', { playerName, lobbyId });
+    console.log('Émission de l\'événement join_lobby avec:', { playerName, lobbyId, color });
     
     // Ajouter un timeout pour la réponse
     const timeout = setTimeout(() => {
@@ -212,12 +212,29 @@ export function joinLobby(playerName, lobbyId) {
       reject(new Error('Délai de réponse dépassé'));
     }, 5000);
     
-    socket.emit('join_lobby', { playerName, lobbyId }, (response) => {
+    socket.emit('join_lobby', { playerName, lobbyId, color }, (response) => {
       clearTimeout(timeout);
       console.log('Réponse reçue pour join_lobby:', response);
       
       if (response && response.success) {
         resolve(response.lobby);
+      } else {
+        reject(new Error(response ? response.message : 'Erreur inconnue'));
+      }
+    });
+  });
+}
+
+export function setPlayerColor(color) {
+  return new Promise((resolve, reject) => {
+    if (!socket) {
+      reject(new Error('Socket non initialisé'));
+      return;
+    }
+
+    socket.emit('set_color', { color }, (response) => {
+      if (response && response.success) {
+        resolve(true);
       } else {
         reject(new Error(response ? response.message : 'Erreur inconnue'));
       }

--- a/server/game/Game.js
+++ b/server/game/Game.js
@@ -34,7 +34,7 @@ class Game {
     // Reconstruire les joueurs
     game.players = {};
     state.players.forEach(pData => {
-      const player = new Player(pData.name, null);
+      const player = new Player(pData.name, null, pData.color || '#FF00A8');
       player.id = pData.id;
       player.money = pData.money;
       player.position = pData.position;
@@ -77,8 +77,8 @@ class Game {
     return game;
   }
 
-  addPlayer(name, socketId) {
-    const player = new Player(name, socketId);
+  addPlayer(name, socketId, color = '#FF00A8') {
+    const player = new Player(name, socketId, color);
     this.players[player.id] = player;
     
     this.log.push(`${name} a rejoint la partie`);
@@ -889,6 +889,7 @@ class Game {
       players: Object.values(this.players).map(player => ({
         id: player.id,
         name: player.name,
+        color: player.color,
         money: player.money,
         position: player.position,
         properties: player.properties.map(p => p.id),

--- a/server/game/Player.js
+++ b/server/game/Player.js
@@ -1,10 +1,11 @@
 const uuid = require('uuid');
 
 class Player {
-  constructor(name, socketId) {
+  constructor(name, socketId, color = '#FF00A8') {
     this.id = uuid.v4();
     this.name = name;
     this.socketId = socketId;
+    this.color = color;
     this.money = 1500; // Montant de départ
     this.position = 0; // Case de départ
     this.properties = [];

--- a/server/socket/gameEvents.js
+++ b/server/socket/gameEvents.js
@@ -71,7 +71,7 @@ function startGame(io, socket, data = {}) {
   
   // Ajouter les joueurs
   lobby.players.forEach(player => {
-    game.addPlayer(player.name, player.id);
+    game.addPlayer(player.name, player.id, player.color);
   });
   
   // Démarrer la partie

--- a/server/socket/handlers.js
+++ b/server/socket/handlers.js
@@ -1,4 +1,4 @@
-const { createLobby, joinLobby, leaveLobby, listLobbies, reconnectPlayer, handleDisconnect } = require('./lobby');
+const { createLobby, joinLobby, leaveLobby, listLobbies, reconnectPlayer, handleDisconnect, setPlayerColor } = require('./lobby');
 const { 
   startGame, 
   rollDice, 
@@ -67,6 +67,11 @@ function initSocketHandlers(io) {
         console.log('Envoi de la réponse list_lobbies:', result);
         callback(result);
       }
+    });
+
+    socket.on('set_color', (data, callback) => {
+      const result = setPlayerColor(socket, data);
+      if (callback) callback(result);
     });
     
     // Événements de jeu


### PR DESCRIPTION
## Summary
- add `color` property to `Player`
- support color during lobby create/join and game start
- allow players to change their color in lobby via new `set_color` event
- render player colors on lobby lists and board tokens
- expose color picker in lobby UI

## Testing
- `npm test`