### PR TITLE
Use async fs operations for game persistence

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -20,7 +20,7 @@ async function startServer() {
     const port = PORT;
     
     // Charger les parties sauvegardées
-    const saved = loadSavedGames();
+    const saved = await loadSavedGames();
     console.log(`Jeux sauvegardés chargés: ${Object.keys(saved).length}`);
     registerLoadedGames(saved);
 

--- a/server/socket/gameEvents.js
+++ b/server/socket/gameEvents.js
@@ -39,7 +39,7 @@ function checkAuth(socket, token) {
   return null;
 }
 
-function startGame(io, socket, data = {}) {
+async function startGame(io, socket, data = {}) {
   const auth = checkAuth(socket, data.token);
   if (auth) return auth;
 
@@ -89,12 +89,12 @@ function startGame(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return { success: true };
 }
 
-function rollDice(io, socket, data = {}) {
+async function rollDice(io, socket, data = {}) {
   const auth = checkAuth(socket, data.token);
   if (auth) return auth;
 
@@ -126,12 +126,12 @@ function rollDice(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
+  await saveGame(game, lobby);
 
   return result;
 }
 
-function startAuctionEvent(io, socket, data = {}) {
+async function startAuctionEvent(io, socket, data = {}) {
   const auth = checkAuth(socket, data.token);
   if (auth) return auth;
 
@@ -165,12 +165,12 @@ function startAuctionEvent(io, socket, data = {}) {
 
   startAuctionTimer(io, lobby);
 
-  saveGame(game, lobby);
+  await saveGame(game, lobby);
 
   return { success: true };
 }
 
-function placeBid(io, socket, data = {}) {
+async function placeBid(io, socket, data = {}) {
   const { amount, token } = data;
   const auth = checkAuth(socket, token);
   if (auth) return auth;
@@ -225,12 +225,12 @@ function placeBid(io, socket, data = {}) {
     startAuctionTimer(io, lobby);
   }
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return result;
 }
 
-function passBid(io, socket, data = {}) {
+async function passBid(io, socket, data = {}) {
   const auth = checkAuth(socket, data.token);
   if (auth) return auth;
 
@@ -275,7 +275,7 @@ function passBid(io, socket, data = {}) {
       gameState: game.getGameState()
     });
     clearAuctionTimer(lobby);
-    saveGame(game, lobby);
+    await saveGame(game, lobby);
     return passResult;
   }
 
@@ -300,12 +300,12 @@ function passBid(io, socket, data = {}) {
     });
   }
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return { success: true };
 }
 
-function activateRevenge(io, socket, data = {}) {
+async function activateRevenge(io, socket, data = {}) {
   const auth = checkAuth(socket, data.token);
   if (auth) return auth;
 
@@ -351,12 +351,12 @@ function activateRevenge(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return result;
 }
 
-function declineRevenge(io, socket, data = {}) {
+async function declineRevenge(io, socket, data = {}) {
   const auth = checkAuth(socket, data.token);
   if (auth) return auth;
 
@@ -402,12 +402,12 @@ function declineRevenge(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return result;
 }
 
-function createAlliance(io, socket, data = {}) {
+async function createAlliance(io, socket, data = {}) {
   const { targetPlayerId, token } = data;
   const auth = checkAuth(socket, token);
   if (auth) return auth;
@@ -450,12 +450,12 @@ function createAlliance(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return result;
 }
 
-function breakAlliance(io, socket, data = {}) {
+async function breakAlliance(io, socket, data = {}) {
   const { unilateral = true, token } = data;
   const auth = checkAuth(socket, token);
   if (auth) return auth;
@@ -498,12 +498,12 @@ function breakAlliance(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return result;
 }
 
-function applyCardEffect(io, socket, data = {}) {
+async function applyCardEffect(io, socket, data = {}) {
   const { cardId, params, token } = data;
   const auth = checkAuth(socket, token);
   if (auth) return auth;
@@ -554,12 +554,12 @@ function applyCardEffect(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return result;
 }
 
-function buyHouse(io, socket, data = {}) {
+async function buyHouse(io, socket, data = {}) {
   const { propertyId, token } = data;
   const auth = checkAuth(socket, token);
   if (auth) return auth;
@@ -594,12 +594,12 @@ function buyHouse(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return result;
 }
 
-function buyHotel(io, socket, data = {}) {
+async function buyHotel(io, socket, data = {}) {
   const { propertyId, token } = data;
   const auth = checkAuth(socket, token);
   if (auth) return auth;
@@ -634,12 +634,12 @@ function buyHotel(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return result;
 }
 
-function mortgageProperty(io, socket, data = {}) {
+async function mortgageProperty(io, socket, data = {}) {
   const { propertyId, token } = data;
   const auth = checkAuth(socket, token);
   if (auth) return auth;
@@ -674,12 +674,12 @@ function mortgageProperty(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return result;
 }
 
-function unmortgageProperty(io, socket, data = {}) {
+async function unmortgageProperty(io, socket, data = {}) {
   const { propertyId, token } = data;
   const auth = checkAuth(socket, token);
   if (auth) return auth;
@@ -714,12 +714,12 @@ function unmortgageProperty(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
-
+  await saveGame(game, lobby);
+  
   return result;
 }
 
-function quitGame(io, socket, data = {}) {
+async function quitGame(io, socket, data = {}) {
   const auth = checkAuth(socket, data.token);
   if (auth) return auth;
 
@@ -746,7 +746,7 @@ function quitGame(io, socket, data = {}) {
     gameState: game.getGameState()
   });
 
-  saveGame(game, lobby);
+  await saveGame(game, lobby);
 
   leaveLobby(socket, { lobbyId: lobby.id });
 

--- a/server/socket/handlers.js
+++ b/server/socket/handlers.js
@@ -77,79 +77,79 @@ function initSocketHandlers(io) {
     });
     
     // Événements de jeu
-    socket.on('start_game', (data, callback) => {
+    socket.on('start_game', async (data, callback) => {
       logger.info(`Événement start_game reçu: ${JSON.stringify(data)}`);
-      const result = startGame(io, socket, data);
-      if (callback) callback(result);
-    });
-    
-    socket.on('roll_dice', (data, callback) => {
-      const result = rollDice(io, socket, data);
-      if (callback) callback(result);
-    });
-    
-    socket.on('place_bid', (data, callback) => {
-      const result = placeBid(io, socket, data);
-      if (callback) callback(result);
-    });
-    
-    socket.on('pass_bid', (data, callback) => {
-      const result = passBid(io, socket, data);
+      const result = await startGame(io, socket, data);
       if (callback) callback(result);
     });
 
-    socket.on('start_auction', (data, callback) => {
-      const result = startAuctionEvent(io, socket, data);
-      if (callback) callback(result);
-    });
-    
-    socket.on('activate_revenge', (data, callback) => {
-      const result = activateRevenge(io, socket, data);
-      if (callback) callback(result);
-    });
-    
-    socket.on('decline_revenge', (data, callback) => {
-      const result = declineRevenge(io, socket, data);
-      if (callback) callback(result);
-    });
-    
-    socket.on('create_alliance', (data, callback) => {
-      const result = createAlliance(io, socket, data);
-      if (callback) callback(result);
-    });
-    
-    socket.on('break_alliance', (data, callback) => {
-      const result = breakAlliance(io, socket, data);
-      if (callback) callback(result);
-    });
-    
-    socket.on('apply_card_effect', (data, callback) => {
-      const result = applyCardEffect(io, socket, data);
+    socket.on('roll_dice', async (data, callback) => {
+      const result = await rollDice(io, socket, data);
       if (callback) callback(result);
     });
 
-    socket.on('buy_house', (data, callback) => {
-      const result = buyHouse(io, socket, data);
+    socket.on('place_bid', async (data, callback) => {
+      const result = await placeBid(io, socket, data);
       if (callback) callback(result);
     });
 
-    socket.on('buy_hotel', (data, callback) => {
-      const result = buyHotel(io, socket, data);
+    socket.on('pass_bid', async (data, callback) => {
+      const result = await passBid(io, socket, data);
       if (callback) callback(result);
     });
 
-    socket.on('mortgage_property', (data, callback) => {
-      const result = mortgageProperty(io, socket, data);
+    socket.on('start_auction', async (data, callback) => {
+      const result = await startAuctionEvent(io, socket, data);
       if (callback) callback(result);
     });
 
-    socket.on('unmortgage_property', (data, callback) => {
-      const result = unmortgageProperty(io, socket, data);
+    socket.on('activate_revenge', async (data, callback) => {
+      const result = await activateRevenge(io, socket, data);
       if (callback) callback(result);
     });
 
-    socket.on('quit_game', (data, callback) => {
-      const result = quitGame(io, socket);
+    socket.on('decline_revenge', async (data, callback) => {
+      const result = await declineRevenge(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('create_alliance', async (data, callback) => {
+      const result = await createAlliance(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('break_alliance', async (data, callback) => {
+      const result = await breakAlliance(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('apply_card_effect', async (data, callback) => {
+      const result = await applyCardEffect(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('buy_house', async (data, callback) => {
+      const result = await buyHouse(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('buy_hotel', async (data, callback) => {
+      const result = await buyHotel(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('mortgage_property', async (data, callback) => {
+      const result = await mortgageProperty(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('unmortgage_property', async (data, callback) => {
+      const result = await unmortgageProperty(io, socket, data);
+      if (callback) callback(result);
+    });
+
+    socket.on('quit_game', async (data, callback) => {
+      const result = await quitGame(io, socket, data);
       if (callback) callback(result);
     });
     

--- a/server/utils/gamePersistence.js
+++ b/server/utils/gamePersistence.js
@@ -1,17 +1,20 @@
 const fs = require('fs');
+const fsp = fs.promises;
 const path = require('path');
 const { SAVE_PATH } = require('../config');
 const Game = require('../game/Game');
 
-function ensureSaveDir() {
-  if (!fs.existsSync(SAVE_PATH)) {
-    fs.mkdirSync(SAVE_PATH, { recursive: true });
+async function ensureSaveDir() {
+  try {
+    await fsp.access(SAVE_PATH);
+  } catch {
+    await fsp.mkdir(SAVE_PATH, { recursive: true });
   }
 }
 
-function saveGame(game, lobby = null) {
+async function saveGame(game, lobby = null) {
   try {
-    ensureSaveDir();
+    await ensureSaveDir();
     const file = path.join(SAVE_PATH, `${game.id}.json`);
 
     const data = { game: game.getGameState() };
@@ -26,18 +29,22 @@ function saveGame(game, lobby = null) {
       };
     }
 
-    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    await fsp.writeFile(file, JSON.stringify(data, null, 2));
   } catch (err) {
     console.error('Erreur lors de la sauvegarde du jeu:', err);
   }
 }
 
-function loadGame(gameId) {
+async function loadGame(gameId) {
   try {
-    ensureSaveDir();
+    await ensureSaveDir();
     const file = path.join(SAVE_PATH, `${gameId}.json`);
-    if (!fs.existsSync(file)) return null;
-    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    try {
+      await fsp.access(file);
+    } catch {
+      return null;
+    }
+    const data = JSON.parse(await fsp.readFile(file, 'utf8'));
 
     const gameState = data.game || data;
     const game = Game.fromState(gameState);
@@ -50,13 +57,13 @@ function loadGame(gameId) {
   }
 }
 
-function loadSavedGames() {
-  ensureSaveDir();
+async function loadSavedGames() {
+  await ensureSaveDir();
   const games = {};
-  const files = fs.readdirSync(SAVE_PATH).filter(f => f.endsWith('.json'));
+  const files = (await fsp.readdir(SAVE_PATH)).filter(f => f.endsWith('.json'));
   for (const f of files) {
     const gameId = path.basename(f, '.json');
-    const g = loadGame(gameId);
+    const g = await loadGame(gameId);
     if (g) games[gameId] = g;
   }
   return games;

--- a/tests/Game.test.js
+++ b/tests/Game.test.js
@@ -235,7 +235,7 @@ describe('Game core methods', () => {
     expect(alice.bankrupt).toBe(true);
   });
 
-  test('save and load game state', () => {
+  test('save and load game state', async () => {
     const p1 = game.addPlayer('Alice', 's1');
     const p2 = game.addPlayer('Bob', 's2');
     jest.spyOn(global.Math, 'random').mockReturnValue(0);
@@ -249,8 +249,8 @@ describe('Game core methods', () => {
 
     game.applyDigitalDisruption(2);
 
-    saveGame(game);
-    const loaded = loadGame(game.id);
+    await saveGame(game);
+    const loaded = await loadGame(game.id);
     expect(loaded).not.toBeNull();
     expect(Object.keys(loaded.game.players)).toHaveLength(2);
     expect(loaded.game.digitalDisruptionTurnsLeft).toBe(2);

--- a/tests/SocketHandlers.test.js
+++ b/tests/SocketHandlers.test.js
@@ -2,7 +2,7 @@ const { createLobby, joinLobby, lobbies, validateToken } = require('../server/so
 const { startGame } = require('../server/socket/gameEvents');
 
 describe('Socket handlers authentication', () => {
-  test('startGame requires valid token', () => {
+  test('startGame requires valid token', async () => {
     const io = { of: () => ({ to: () => ({ emit: jest.fn() }) }) };
     const hostSocket = { id: 's1', join: jest.fn(), to: () => ({ emit: jest.fn() }), disconnect: jest.fn() };
     const playerSocket = { id: 's2', join: jest.fn(), to: () => ({ emit: jest.fn() }) };
@@ -14,10 +14,10 @@ describe('Socket handlers authentication', () => {
     expect(validateToken(hostSocket, createRes.lobby.token)).toBe(true);
     expect(validateToken(hostSocket, 'bad')).toBe(false);
 
-    const bad = startGame(io, hostSocket, { token: 'bad' });
+    const bad = await startGame(io, hostSocket, { token: 'bad' });
     expect(bad.success).toBe(false);
 
-    const good = startGame(io, hostSocket, { token: createRes.lobby.token });
+    const good = await startGame(io, hostSocket, { token: createRes.lobby.token });
     expect(good.success).toBe(true);
     expect(lobbies[lobbyId].game).toBeDefined();
   });


### PR DESCRIPTION
## Summary
- refactor game persistence to use `fs.promises`
- update server startup and socket events to await async saves/loads
- adjust tests for async behaviour

## Testing
- `npm test`