### PR TITLE
Add end-game leaderboard support

### DIFF
--- a/client/src/components/Leaderboard.js
+++ b/client/src/components/Leaderboard.js
@@ -1,0 +1,15 @@
+export function renderLeaderboard(ranking, onReplay) {
+  const app = document.getElementById('app');
+  if (!app) return;
+  const items = ranking
+    .map((p, i) => `<li>${i + 1}. ${p.name} - ${p.money}€</li>`) // money euro sign
+    .join('');
+  app.innerHTML = `
+    <div class="leaderboard-screen">
+      <h2>Classement final</h2>
+      <ul class="leaderboard-list">${items}</ul>
+      <button id="replay-btn" class="btn">Rejouer</button>
+    </div>`;
+  const btn = document.getElementById('replay-btn');
+  if (btn) btn.addEventListener('click', () => onReplay && onReplay());
+}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -26,6 +26,7 @@ import { getUIState, subscribeToUIState } from './state/ui';
 import { getPlayerState, setPlayerState, clearPlayerState } from './state/player';
 import { getUsername, setUsername } from './state/username';
 import { renderProperty } from './components/Property.js';
+import { renderLeaderboard } from './components/Leaderboard.js';
 
 // Initialiser la connexion socket
 async function handleSocketConnect() {
@@ -654,6 +655,10 @@ function updateUIState(uiState) {
   // Gérer les alliances
   if (uiState.alliance) {
     handleAllianceUI(uiState.alliance);
+  }
+
+  if (uiState.leaderboard) {
+    renderLeaderboard(uiState.leaderboard, handleQuitGame);
   }
 }
 

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -1,11 +1,12 @@
 import io from 'socket.io-client';
 import { updateGameState } from './state/game';
-import { 
+import {
   setDiceResult,
   setAuctionState,
   setCardState,
   setRevengeState,
-  setAllianceState
+  setAllianceState,
+  setLeaderboard
 } from './state/ui';
 
 // Gestionnaire de connexion au serveur
@@ -152,6 +153,12 @@ export function initSocket(url, onConnect) {
 
   socket.on('player_quit', ({ playerId, gameState }) => {
     console.log('Joueur a quitté la partie:', playerId);
+    updateGameState(gameState);
+  });
+
+  socket.on('game_ended', ({ result, gameState }) => {
+    console.log('Partie terminée');
+    setLeaderboard(result.ranking);
     updateGameState(gameState);
   });
   

--- a/client/src/state/ui.js
+++ b/client/src/state/ui.js
@@ -3,7 +3,8 @@ let uiState = {
   auction: null,
   card: null,
   revenge: null,
-  alliance: null
+  alliance: null,
+  leaderboard: null
 };
 
 const listeners = [];
@@ -30,6 +31,11 @@ export function setRevengeState(revenge) {
 
 export function setAllianceState(alliance) {
   uiState = { ...uiState, alliance };
+  notifyListeners();
+}
+
+export function setLeaderboard(leaderboard) {
+  uiState = { ...uiState, leaderboard };
   notifyListeners();
 }
 

--- a/server/socket/gameEvents.js
+++ b/server/socket/gameEvents.js
@@ -68,6 +68,14 @@ async function startGame(io, socket, data = {}) {
   
   // Initialiser le jeu
   const game = new Game(data.boardPreset);
+
+  // Lors de la fin de partie, informer tous les joueurs
+  game.onEnd((result) => {
+    io.of('/game').to(lobby.id).emit('game_ended', {
+      result,
+      gameState: game.getGameState()
+    });
+  });
   
   // Ajouter les joueurs
   lobby.players.forEach(player => {

--- a/tests/GameEndEvent.test.js
+++ b/tests/GameEndEvent.test.js
@@ -1,0 +1,17 @@
+const Game = require('../server/game/Game');
+
+describe('Game end event', () => {
+  test('endGame triggers callback with ranking', () => {
+    const game = new Game();
+    const p1 = game.addPlayer('Alice', 's1');
+    const p2 = game.addPlayer('Bob', 's2');
+    game.startGame();
+    p1.money = 100;
+    p2.money = 200;
+    const cb = jest.fn();
+    game.onEnd(cb);
+    const result = game.endGame(p2);
+    expect(cb).toHaveBeenCalled();
+    expect(result.ranking[0].name).toBe('Bob');
+  });
+});

--- a/tests/Leaderboard.test.js
+++ b/tests/Leaderboard.test.js
@@ -1,0 +1,21 @@
+describe('Leaderboard component', () => {
+  test('renders ranking', async () => {
+    const container = { innerHTML: '' };
+    const button = { addEventListener: jest.fn() };
+    global.document = {
+      getElementById: jest.fn((id) => {
+        if (id === 'app') return container;
+        if (id === 'replay-btn') return button;
+        return null;
+      })
+    };
+    const mod = await import('../client/src/components/Leaderboard.js');
+    const { renderLeaderboard } = mod;
+    renderLeaderboard([
+      { name: 'Bob', money: 200 },
+      { name: 'Alice', money: 100 }
+    ]);
+    expect(container.innerHTML).toContain('Bob');
+    expect(container.innerHTML).toContain('Alice');
+  });
+});


### PR DESCRIPTION
## Summary
- compute ranking when a game ends
- emit `game_ended` event from server
- add leaderboard handling in client state and socket
- render final ranking with a replay button
- tests for end-game callback and leaderboard component

## Testing
- `npm test`