### PR TITLE
Ajouter CI GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
## Notes
- Ajout d’un workflow GitHub Actions exécutant `npm ci` puis `npm test` sur `ubuntu-latest`.
- Le workflow se déclenche sur les pushes vers n’importe quelle branche et sur les pull requests.

## Testing
- `npm test`