### PR TITLE
Add trading and customization options

### DIFF
--- a/server/game/Board.js
+++ b/server/game/Board.js
@@ -2,8 +2,12 @@ const Property = require('./Property');
 const presets = require('./boardPresets');
 
 class Board {
-  constructor(presetName = 'classic') {
-    this.preset = presets[presetName] || presets.classic;
+  constructor(preset = 'classic') {
+    if (typeof preset === 'object') {
+      this.preset = preset;
+    } else {
+      this.preset = presets[preset] || presets.classic;
+    }
     this.squares = this.initializeBoard();
   }
 

--- a/server/game/Player.js
+++ b/server/game/Player.js
@@ -1,11 +1,13 @@
 const uuid = require('uuid');
 
 class Player {
-  constructor(name, socketId, color = '#FF00A8') {
+  constructor(name, socketId, color = '#FF00A8', options = {}) {
     this.id = uuid.v4();
     this.name = name;
     this.socketId = socketId;
     this.color = color;
+    this.isSpectator = !!options.spectator;
+    this.isAI = !!options.ai;
     this.money = 1500; // Montant de départ
     this.position = 0; // Case de départ
     this.properties = [];

--- a/server/game/cards/CardDeck.js
+++ b/server/game/cards/CardDeck.js
@@ -1,10 +1,11 @@
 const KcrapCard = require('./KcrapCard');
 
 class CardDeck {
-  constructor() {
+  constructor(customCards = []) {
     this.cards = [];
     this.currentIndex = 0;
-    
+    this.customCards = customCards;
+
     this.initialize();
   }
 
@@ -68,7 +69,13 @@ class CardDeck {
         'Allez directement en prison et ne passez pas par la case départ'
       ));
     }
-    
+
+    if (Array.isArray(this.customCards)) {
+      this.customCards.forEach(c => {
+        this.cards.push(new KcrapCard(c.id, c.type, c.title, c.description));
+      });
+    }
+
     // Mélanger les cartes
     this.shuffle();
   }


### PR DESCRIPTION
## Summary
- support spectators and AI players when adding players
- allow custom board presets and card decks
- add property and money trading between players
- store spectator/AI flags in game state
- test new features

## Testing
- `npm test`