### PR TITLE
Prepare Monopoly app for production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npm install
+      - run: npm ci
       - run: npm test
+      - run: npm run build
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/build-push-action@v4
+        with:
+          push: false
+          tags: monopoly-kcrap:ci

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Les tests Jest se trouvent dans le dossier `tests/` :
 npm test
 ```
 
+Un workflow GitHub Actions (`.github/workflows/ci.yml`) exécute les tests et
+construit l'image Docker à chaque push pour fiabiliser les mises en production.
+
 ## Déploiement avec Docker
 
 Une configuration Docker est disponible pour faciliter la mise en production.
@@ -77,6 +80,13 @@ Lancez le conteneur en précisant éventuellement les variables d'environnement�
 
 ```bash
 docker run -p 3000:3000 --env-file .env monopoly-kcrap
+```
+
+Des scripts pratiques sont fournis dans `scripts/` :
+
+```bash
+./scripts/build_image.sh      # construit l'image Docker
+./scripts/run_container.sh    # lance le conteneur
 ```
 
 ### Sauvegarde et reconnexion

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  }
+};

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Build the production Docker image
+IMAGE_NAME=${1:-monopoly-kcrap:latest}
+docker build -t $IMAGE_NAME .

--- a/scripts/run_container.sh
+++ b/scripts/run_container.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Run the application container
+IMAGE_NAME=${1:-monopoly-kcrap:latest}
+PORT=${PORT:-3000}
+docker run -p $PORT:3000 --env-file .env $IMAGE_NAME

--- a/tests/ClientUtils.test.js
+++ b/tests/ClientUtils.test.js
@@ -1,0 +1,49 @@
+import { formatMoney, clamp, randomInt } from '../client/src/utils/helpers.js';
+import { setConfig, getConfig } from '../client/src/config.js';
+import { setUsername, getUsername } from '../client/src/state/username.js';
+
+describe('client utilities', () => {
+  test('formatMoney formats euros', () => {
+    const result = formatMoney(1500);
+    expect(result).toMatch(/1\D*500\D*€/);
+  });
+
+  test('clamp keeps value within range', () => {
+    expect(clamp(5, 1, 10)).toBe(5);
+    expect(clamp(-1, 0, 3)).toBe(0);
+    expect(clamp(10, 0, 3)).toBe(3);
+  });
+
+  test('randomInt returns value in range', () => {
+    for (let i = 0; i < 10; i++) {
+      const v = randomInt(1, 3);
+      expect(v).toBeGreaterThanOrEqual(1);
+      expect(v).toBeLessThanOrEqual(3);
+    }
+  });
+
+  test('config setters and getters work', () => {
+    setConfig({ apiBaseUrl: '/api' });
+    expect(getConfig('apiBaseUrl')).toBe('/api');
+    const cfg = getConfig();
+    expect(cfg.socketNamespace).toBe('/game');
+  });
+});
+
+describe('username persistence', () => {
+  beforeEach(() => {
+    global.localStorage = {
+      data: {},
+      getItem(k){ return this.data[k]; },
+      setItem(k,v){ this.data[k]=v; },
+      removeItem(k){ delete this.data[k]; }
+    };
+  });
+
+  test('setUsername and getUsername store value', () => {
+    setUsername('Alice');
+    expect(getUsername()).toBe('Alice');
+    setUsername('');
+    expect(getUsername()).toBe('');
+  });
+});

--- a/tests/LobbyEdgeCases.test.js
+++ b/tests/LobbyEdgeCases.test.js
@@ -1,0 +1,23 @@
+const { createLobby, joinLobby, lobbies, handleDisconnect } = require('../server/socket/lobby');
+
+describe('lobby edge cases', () => {
+  test('createLobby fails with empty parameters', () => {
+    const socket = { id: 'x', join: jest.fn() };
+    const res = createLobby(socket, { playerName: '', lobbyName: '' });
+    expect(res.success).toBe(false);
+  });
+
+  test('joinLobby fails if lobby does not exist', () => {
+    const socket = { id: 'y', join: jest.fn(), to: () => ({ emit: jest.fn() }) };
+    const res = joinLobby(socket, { playerName: 'Bob', lobbyId: 'UNKNOWN' });
+    expect(res.success).toBe(false);
+  });
+
+  test('handleDisconnect marks player disconnected', () => {
+    const socket = { id: 'z', join: jest.fn(), leave: jest.fn(), to: () => ({ emit: jest.fn() }) };
+    const create = createLobby(socket, { playerName: 'Alice', lobbyName: 'L1' });
+    const lobbyId = create.lobby.id;
+    handleDisconnect(socket);
+    expect(lobbies[lobbyId].players[0].connected).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for client utilities and lobby edge cases
- introduce Jest config with Babel support
- add Docker deployment helper scripts
- update CI workflow to build and test
- document Docker scripts and CI in README

## Testing
- `npm test`